### PR TITLE
Add support for Laravel 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `settings` will be documented in this file.
 
+## 1.0.4 - 2025-02-25
+
+### Added
+
+- Added support for Laravel 12.
+
 ## 1.0.3 - 2024-03-12
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^10.0|^11.0",
+        "laravel/framework": "^10.0|^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "autoload": {


### PR DESCRIPTION
Updated `composer.json` to include compatibility with Laravel 12. Documented the change in the changelog under version 1.0.4.